### PR TITLE
New features, additional collectable categories and the ability to specify which metrics to collect.

### DIFF
--- a/CollectableMetrics.md
+++ b/CollectableMetrics.md
@@ -1,0 +1,171 @@
+Possible metrics to collect:
+
+Physical Cpu Load
+	Cpu Load (1 Minute Avg)
+	Cpu Load (5 Minute Avg)
+	Cpu Load (15 Minute Avg)
+
+Vcpu
+	Alloc Max
+	Alloc Min
+	Alloc Min Limited
+	Alloc Shares
+	% CoStop
+	% CPU Latency
+	% Demand
+	Effective Min (MHz)
+	% Idle
+	% Max Limited
+	% Memory Latency
+	Migrates/sec
+	% Overlap
+	Physical Cpu
+	Quantum Expires/sec
+	% Ready
+	% Run
+	% Swap Wait
+	Switches/sec
+	% System
+	% Used
+	% VmWait
+	% Wait
+	Wakeups/sec
+
+Network Port
+	Actions Posted/sec
+	Broadcast Packets Received/sec
+	Broadcast Packets Transmitted/sec
+	Full Duplex?
+	Link Speed (Mb/s)
+	Link Up?
+	MBits Received/sec
+	MBits Transmitted/sec
+	Multicast Packets Received/sec
+	Multicast Packets Transmitted/sec
+	% Outbound Packets Dropped
+	Packets Received/sec
+	Packets Transmitted/sec
+	% Received Packets Dropped
+
+Virtual Disk
+	Average MilliSec/Read
+	Average MilliSec/Write
+	Commands/sec
+	MBytes Read/sec
+	MBytes Written/sec
+	Reads/sec
+	Writes/sec
+
+Physical Disk Adapter
+	Aborts/sec
+	Average Driver MilliSec/Command
+	Average Driver MilliSec/Read
+	Average Driver MilliSec/Write
+	Average Guest MilliSec/Command
+	Average Guest MilliSec/Read
+	Average Guest MilliSec/Write
+	Average Kernel MilliSec/Command
+	Average Kernel MilliSec/Read
+	Average Kernel MilliSec/Write
+	Average Queue MilliSec/Command
+	Average Queue MilliSec/Read
+	Average Queue MilliSec/Write
+	Commands/sec
+	Conflicts/sec
+	Failed Bytes Read/sec
+	Failed Bytes Written/sec
+	Failed Commands/sec
+	Failed Reads/sec
+	Failed Reserves/sec
+	Failed Writes/sec
+	MBytes Read/sec
+	MBytes Written/sec
+	PAE Commands/sec
+	PAE Copies/sec
+	Reads/sec
+	Reserves/sec
+	Resets/sec
+	Split Commands/sec
+	Split Copies/sec
+	Writes/sec
+
+Group Memory
+	% Active Estimate
+	% Active Fast Estimate
+	% Active Next Estimate
+	% Active Slow Estimate
+	Alloc Max
+	Alloc Min
+	Alloc Min Limited
+	Alloc Shares
+	Checkpoint Read MBytes
+	Checkpoint Target MBytes
+	Commit Pages Per Share
+	Commit Target MBytes
+	Compressed Memory MBytes
+	Compression MBytes/sec
+	Copy On Write Hint MBytes
+	Decompression MBytes/sec
+	Guest Memory on Numa Node 0
+	Guest Memory on Numa Node 1
+	Guest Memory on Numa Node 2
+	Guest Memory on Numa Node 3
+	Llswap Read MBytes/sec
+	Llswap Written MBytes/sec
+	Members
+	Memctl?
+	Memctl Max MBytes
+	Memctl MBytes
+	Memctl Target MBytes
+	Memory Granted Size MBytes
+	Memory Size MBytes
+	Numa Home Nodes
+	Numa % Local
+	Numa Local Memory MBytes
+	Numa Rebalance Count Delta
+	Numa Remote Memory MBytes
+	Overhead Max MBytes
+	Overhead MBytes
+	Overhead UW MBytes
+	Shared MBytes
+	Shared Saved MBytes
+	Swapped MBytes
+	Swap Read MBytes/sec
+	Swap Target MBytes
+	Swap Written MBytes/sec
+	Target Size MBytes
+	Touched MBytes
+	Touched Write MBytes
+	Used Compressed Memory MBytes
+	VMM Overhead Memory on Numa Node 0
+	VMM Overhead Memory on Numa Node 1
+	VMM Overhead Memory on Numa Node 2
+	VMM Overhead Memory on Numa Node 3
+	Zero MBytes
+
+Memory
+	Free MBytes
+	Kernel Managed MBytes
+	Kernel MBytes
+	Kernel MinFree MBytes
+	Kernel Reserved MBytes
+	Kernel State
+	Kernel Unreserved MBytes
+	Machine MBytes
+	Memctl Current MBytes
+	Memctl Max MBytes
+	Memctl Target MBytes
+	Memory Overcommit (15 Minute Avg)
+	Memory Overcommit (1 Minute Avg)
+	Memory Overcommit (5 Minute Avg)
+	NonKernel MBytes
+	PShare Common MBytes
+	PShare Savings MBytes
+	PShare Shared MBytes
+	Swap MBytes Read/sec
+	Swap MBytes Write/sec
+	Swap Target MBytes
+	Swap Used MBytes
+	Total Compressed MBytes
+	Total Saved By Compression MBytes
+

--- a/CollectableMetrics.md
+++ b/CollectableMetrics.md
@@ -1,11 +1,11 @@
-Possible metrics to collect:
+# Possible Metrics to Collect:
 
-Physical Cpu Load
+# Physical Cpu Load
 	Cpu Load (1 Minute Avg)
 	Cpu Load (5 Minute Avg)
 	Cpu Load (15 Minute Avg)
 
-Vcpu
+# Vcpu
 	Alloc Max
 	Alloc Min
 	Alloc Min Limited
@@ -31,7 +31,7 @@ Vcpu
 	% Wait
 	Wakeups/sec
 
-Network Port
+# Network Port
 	Actions Posted/sec
 	Broadcast Packets Received/sec
 	Broadcast Packets Transmitted/sec
@@ -47,7 +47,7 @@ Network Port
 	Packets Transmitted/sec
 	% Received Packets Dropped
 
-Virtual Disk
+# Virtual Disk
 	Average MilliSec/Read
 	Average MilliSec/Write
 	Commands/sec
@@ -56,7 +56,7 @@ Virtual Disk
 	Reads/sec
 	Writes/sec
 
-Physical Disk Adapter
+# Physical Disk Adapter
 	Aborts/sec
 	Average Driver MilliSec/Command
 	Average Driver MilliSec/Read
@@ -89,7 +89,7 @@ Physical Disk Adapter
 	Split Copies/sec
 	Writes/sec
 
-Group Memory
+# Group Memory
 	% Active Estimate
 	% Active Fast Estimate
 	% Active Next Estimate
@@ -143,7 +143,7 @@ Group Memory
 	VMM Overhead Memory on Numa Node 3
 	Zero MBytes
 
-Memory
+# Memory
 	Free MBytes
 	Kernel Managed MBytes
 	Kernel MBytes

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Daemon has to be deployed on every vSphere server. It collects esxtop's statisti
 
 # Preparing for first use
 1. Enable remote SSH console on vSphere hosts
-2. Place daemon and init scripts in /bin and /etc/init.d directories
-3. Edit influxdb_server and influxdb_dbname in /bin/esxtop-collect
-4. chmod 755 /bin/esxtop-collect /etc/init.d/esxtop-collect
-5. chkconfig esxtop-collect on
-6. /etc/init.d/esxtop-collect start
+2. Edit influxdb_server and influxdb_dbname in /bin/esxtop-collect
+3. Edit metrics_collect lists for each category to include the metrics you wish to collect. Reference CollectableMetrics.md for full list.
+4. Place daemon and init scripts in /bin and /etc/init.d directories
+5. Set ohostname to the desired hostname to be reported if you need to override the hostname, leave as None to use system hostname
+6. chmod 755 /bin/esxtop-collect /etc/init.d/esxtop-collect
+7. chkconfig esxtop-collect on
+8. /etc/init.d/esxtop-collect start
 
 # Making installation easier on other hosts in a cluster
 
@@ -25,3 +27,17 @@ Install
 2. chkconfig esxtop-collect on
 3. /etc/init.d/esxtop-collect start
 
+# Known issues
+
+When pulling the "Group Memory" data if you have VMs with a naming scheme that ends with .[0-9]+ you will not be able to pull metrics.
+Processes on the host as listed with the process name followed by .$PID, VM names are listed the same except without the .$PID, this
+makes filtering the host processes from the VMs difficult.
+
+Example:
+
+	Host process:
+	"\\esxhost1\Group Memory(376:init.33332)\Shared MBytes"
+	VM:
+	"\\esxhost1\Group Memory(46414637:linuxvm)\Shared MBytes"
+
+VMs named something like linuxbox.12432 will be filtered.

--- a/bin/esxtop-collect
+++ b/bin/esxtop-collect
@@ -10,6 +10,17 @@ import os
 p = 0
 influxdb_server = 'changeme.localnetwork.address'
 influxdb_dbname = 'db_name_to_collect_to'
+
+# See file CollectableMetrics.md to see what metrics are available for each category
+metrics_collect = { 'Physical Cpu Load':[ 'Cpu Load (1 Minute Avg)' ], \
+			'Vcpu':[ '% Used', '% Run', '% VmWait', '% Ready', '% CoStop' ], \
+			'Network Port':[ 'MBits Transmitted/sec', 'MBits Received/sec', '% Outbound Packets Dropped', '% Received Packets Dropped' ], \
+			'Virtual Disk':[ 'MBytes Read/sec', 'MBytes Written/sec' ], \
+			'Physical Disk Adapter':[ 'MBytes Read/sec', 'MBytes Written/sec', 'Average Driver MilliSec/Command', 'Average Kernel MilliSec/Command', 'Average Guest MilliSec/Command', 'Average Queue MilliSec/Command' ], \
+			'Group Memory':[ 'Swap Read MBytes/sec', 'Swap Written MBytes/sec', 'Memory Granted Size MBytes' ], \
+			'Memory':[ 'Memory Overcommit (1 Minute Avg)', 'Swap MBytes Read/sec', 'Swap MBytes Write/sec', 'PShare Shared MBytes', 'PShare Savings MBytes' ]
+		}
+
 data = ''
 def sigterm_handler(_signo, _stack_frame):
 	print "Received signal", _signo
@@ -20,6 +31,9 @@ def sigterm_handler(_signo, _stack_frame):
 	exit(0)
 signal.signal(signal.SIGTERM, sigterm_handler)
 timezone = timedelta(hours=3)
+# Override Hostname
+# if ohostname is None then use hostname from esxtop
+ohostname = None
 
 
 def main ():
@@ -27,7 +41,7 @@ def main ():
 	#print "start 5 minute cycle"
 	p = Popen(['/bin/esxtop', '-b', '-l'
 	, '-n', '61' # 5 mins + 1 dummy iteration
-	], bufsize=1, stdout=PIPE)#, stdout=PIPE)
+	], bufsize=1, stdout=PIPE)
 	start = False
 	first_line_dropped = False
 	head = []
@@ -40,7 +54,8 @@ def main ():
 			if first_line_dropped:
 				date = datetime.strptime(line[0], '"%m/%d/%Y %H:%M:%S"') #+ timezone
 				date = int(mktime(date.timetuple())) * 1000000000
-				for i in indexes: 
+				for i in indexes:
+					#print `head[i]` 
 					data += "%s,%s value=%s %s\n" % (head[i]['metric'], head[i]['tags'], line[i].replace('"', ''), date)
 				for i_vm in vcpuindexes: 
 					for i_vcpu in vcpuindexes[i_vm]: 
@@ -49,7 +64,12 @@ def main ():
 						for i_vstat in vcpuindexes[i_vm][i_vcpu]: 
 							values += '%s%s=%s' % (delim, i_vstat, line[vcpuindexes[i_vm][i_vcpu][i_vstat]].replace('"', ''))
 							delim = ','
-						data += "vcpu,host=%s,vm=%s,vcpu=%s %s %s\n" % (head[vcpuindexes[i_vm][i_vcpu][i_vstat]]['host'],i_vm, i_vcpu, values, date)
+						if ohostname:
+							hostname = ohostname
+						else:
+							hostname = head[vcpuindexes[i_vm][i_vcpu][i_vstat]]['host']
+						data += "vcpu,host=%s,vm=%s,vcpu=%s %s %s\n" % (hostname, i_vm, i_vcpu, values, date)
+				#print `data`
 				writedata()
 			else:
 				first_line_dropped = True
@@ -64,22 +84,88 @@ def main ():
 				# 1 - hostname ; 2 - stat type ; 3- object ; 4 - metric name
 				if m:
 					if m.group(2) == "Virtual Disk" and m.group(3).find(':') > 0:
-						start = True
-						indexes.append(i)
-						# 3 - servername:device name
-						s = m.group(3).replace(' ', '\\ ').split(':', 1)
-						head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
-									'tags' : "stat_type=%s,host=%s,vm=%s,device=%s" % (m.group(2).replace(' ', '\\ '), m.group(1).replace(' ', '\\ '), s[0], s[1])}
-					elif m.group(2) == "Network Port":
-						start = True
-						indexes.append(i)
-						# 3 - vswitch:...:...:device name
-						s = m.group(3).replace(' ', '\\ ').split(':')
-						head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
-									'tags' : "stat_type=%s,host=%s,switch=%s,device=%s" % (m.group(2).replace(' ', '\\ '), m.group(1).replace(' ', '\\ '), s[0], s[-1])}
-					elif m.group(2) == "Vcpu" and m.group(3).find('vmx-vcpu') > 0:
+						if m.group(4) in metrics_collect['Virtual Disk']:
 							start = True
-					#		indexes.append(i)
+							indexes.append(i)
+							# 3 - servername:device name
+							s = m.group(3).replace(' ', '\\ ').split(':', 1)
+							if ohostname:
+								hostname = ohostname
+							else:
+								hostname = m.group(1).replace(' ', '\\ ')
+							head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
+										'tags' : "stat_type=%s,host=%s,vm=%s,device=%s" % (m.group(2).replace(' ', '\\ '), hostname, s[0], s[1])}
+					elif m.group(2) == "Network Port":
+						if m.group(4) in metrics_collect['Network Port']:
+							start = True
+							indexes.append(i)
+							# 3 - vswitch:...:...:device name
+							s = m.group(3).replace(' ', '\\ ').split(':')
+							if ohostname:
+								hostname = ohostname
+							else:
+								hostname = m.group(1).replace(' ', '\\ ')
+
+							head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
+										'tags' : "stat_type=%s,host=%s,switch=%s,device=%s" % (m.group(2).replace(' ', '\\ '), hostname, s[0], s[-1])}
+					elif m.group(2) == "Group Memory":
+						if m.group(4) in metrics_collect['Group Memory']:
+							# 3 - group id : vmname/process name . PID (if process)
+							# examples:  46414637:vmname
+							#            5171:openwsmand.36067
+							s = m.group(3).replace(' ', '\\ ').split(':', 1)
+							# ***BUG***
+							# This will match anything that ends with a dot followed by only digits at the end of the line.
+							# If users name their vms like linuxbox.123 then these will match and be considered processes and ignored
+							# without trying to collect and match a valid list of real VMs on the host I don't see a quick fix for this
+							# I'll try to come back later and fix it, but right now this works well enough for me. Sorry.
+							if not re.match("^.*\.[0-9]+$", s[-1]):
+								# This is a VM, continue to actually process this line
+								start = True
+								indexes.append(i)
+								if ohostname:
+									hostname = ohostname
+								else:
+									hostname = m.group(1).replace(' ', '\\ ')
+								head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
+										'tags' : "stat_type=%s,host=%s,vm=%s" % (m.group(2).replace(' ', '\\ '), hostname, s[-1])}
+					elif m.group(2) == "Physical Disk Adapter":
+						if m.group(4) in metrics_collect['Physical Disk Adapter']:
+							start = True
+							indexes.append(i)
+							# 3 - vmhba
+							s = m.group(3).replace(' ', '\\ ').split(':')
+							if ohostname:
+								hostname = ohostname
+							else:
+								hostname =  m.group(1).replace(' ', '\\ ')
+							head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
+										'tags' : "stat_type=%s,host=%s,device=%s" % (m.group(2).replace(' ', '\\ '), hostname, s[0])}
+					elif m.group(2) == "Memory":
+						if m.group(4) in metrics_collect['Memory']:
+							start = True
+							indexes.append(i)
+							# 3 - NULL
+							if ohostname:
+								hostname = ohostname
+							else:
+								hostname =  m.group(1).replace(' ', '\\ ')
+							head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
+										'tags' : "stat_type=%s,host=%s" % (m.group(2).replace(' ', '\\ '), hostname)}
+					elif m.group(2) == "Physical Cpu Load":
+						if m.group(4) in metrics_collect['Physical Cpu Load']:
+							start = True
+							indexes.append(i)
+							# 3 - NULL
+							if ohostname:
+								hostname = ohostname
+							else:
+								hostname =  m.group(1).replace(' ', '\\ ')
+							head[i] = {'metric' : m.group(4).replace(' ', '\\ '),
+										'tags' : "stat_type=%s,host=%s" % (m.group(2).replace(' ', '\\ '), hostname)}
+					elif m.group(2) == "Vcpu" and m.group(3).find('vmx-vcpu') > 0:
+						if m.group(4) in metrics_collect['Vcpu']:
+							start = True
 					#		# ...:vmname:...:cpu num:vmname
 							s = m.group(3).replace(':vmx-', ':').replace(' ', '\\ ').split(':')
 							if not vcpuindexes.has_key(s[-1]):
@@ -87,8 +173,11 @@ def main ():
 							if not vcpuindexes[s[-1]].has_key(s[-2]):
 								vcpuindexes[s[-1]][s[-2]] = {}
 							vcpuindexes[s[-1]][s[-2]][m.group(4).replace('% ', '').replace(' ', '')] = i
-							head[i] = {'host' : m.group(1).replace(' ', '\\ ')}
-							
+							if ohostname:
+								hostname = ohostname
+							else:
+								hostname = m.group(1).replace(' ', '\\ ')
+							head[i] = {'host' : hostname}
 	#print data
 	#print "end 5 minute cycle"
 	#writedata()
@@ -98,7 +187,7 @@ def writedata():
 	global data
 	try:
 		#print data
-		#print "wrining " + str(len(data))
+		#print "writing " + str(len(data))
 		r = urllib2.Request('http://%s/write?db=%s' % (influxdb_server, influxdb_dbname), data)#, {'Content-Type': 'application/octet-stream'})
 		r.add_header('Content-Length', '%d' % len(data))
 		r.add_header('Content-Type', 'application/octet-stream')
@@ -109,7 +198,6 @@ def writedata():
 		print "Data buffer len:" + str(len(data))
 	if len(data) > 104857600: # 100MB
 		data = ''
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Additions:
CellectableMetrics.md - A list of all the available categories / metrics you can collect at this time (at least from my sample data from my test system, possibly an older version of VMware)
Override hostname - Override the system hostname in case of inconsistencies in naming scheme across a cluster.
Additional categories that can have metrics collected: Memory, Group Memory, Physical Cpu Load, Physical Disk Adapter
Specify which metrics to collect - metrics_collect is a dictionary of lists which you can put in the metrics you want to collecting instead of grabbing all metrics from each category.

Known Issue:
The formatting for Group Memory makes it impossible to differentiate from a local host processes (which are filtered) and a VM that has a name that ends with .<numbers>, example: linuxbox.23431
Names like that will be filtered. I don't see a quick an easy fix right now other than compiling a list of valid VMs from another metric and using that as a reference to validate each line as VM or host process. That has it's own issues, hopefully the vast majority of people don't name their VMs like that.